### PR TITLE
fix: VST3 system install path in Makfile

### DIFF
--- a/plugins/dfzitarev1/Makefile
+++ b/plugins/dfzitarev1/Makefile
@@ -19,7 +19,7 @@ LADSPA_DIR ?= $(LIBDIR)/ladspa
 ifneq ($(MACOS_OR_WINDOWS),true)
 LV2_DIR ?= $(LIBDIR)/lv2
 VST_DIR ?= $(LIBDIR)/vst
-VST3_DIR ?= $(LIBDIR)/vs3
+VST3_DIR ?= $(LIBDIR)/vst3
 endif
 ifeq ($(MACOS),true)
 LV2_DIR ?= /Library/Audio/Plug-Ins/LV2


### PR DESCRIPTION
Signed-off-by: Christopher Arndt <chris@chrisarndt.de>